### PR TITLE
Don't get items in __init__

### DIFF
--- a/src/collective/glossary/browser/templates/term.pt
+++ b/src/collective/glossary/browser/templates/term.pt
@@ -9,7 +9,7 @@
     <metal:content-core fill-slot="content-core">
       <metal:content-core define-macro="content-core">
         <div class="term"
-             tal:define="item view/get_item">
+             tal:define="item view/get_entry">
           <div class="image"
                tal:condition="item/image">
             <img tal:attributes="src item/image/url;

--- a/src/collective/glossary/browser/templates/term.pt
+++ b/src/collective/glossary/browser/templates/term.pt
@@ -9,7 +9,7 @@
     <metal:content-core fill-slot="content-core">
       <metal:content-core define-macro="content-core">
         <div class="term"
-             tal:define="item view/item">
+             tal:define="item view/get_item">
           <div class="image"
                tal:condition="item/image">
             <img tal:attributes="src item/image/url;

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -4,7 +4,6 @@ from collective.glossary.interfaces import IGlossarySettings
 from collective.glossary.interfaces import ITerm
 from plone import api
 from plone.memoize import ram
-
 from Products.Five.browser import BrowserView
 
 import json
@@ -26,7 +25,7 @@ class TermView(BrowserView):
         self.request = request
 
     def get_entry(self):
-        """get term in the desired format"""
+        """Get term in the desired format"""
 
         scales = self.context.unrestrictedTraverse('@@images')
         image = scales.scale('image', None)

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -25,7 +25,7 @@ class TermView(BrowserView):
         self.context = context
         self.request = request
 
-    def get_item(self):
+    def get_entry(self):
         """get term in the desired format"""
 
         scales = self.context.unrestrictedTraverse('@@images')
@@ -47,8 +47,8 @@ class GlossaryView(BrowserView):
         self.request = request
 
     @ram.cache(_catalog_counter_cachekey)
-    def get_items(self):
-        """Get glossary items and keep them in the desired format"""
+    def get_entries(self):
+        """Get glossary entries and keep them in the desired format"""
 
         catalog = api.portal.get_tool('portal_catalog')
         path = '/'.join(self.context.getPhysicalPath())
@@ -80,11 +80,11 @@ class GlossaryView(BrowserView):
 
     def letters(self):
         """Return all letters sorted"""
-        return sorted(self.get_items().keys())
+        return sorted(self.get_entries().keys())
 
     def terms(self, letter):
         """Return all terms of one letter"""
-        return self.get_items()[letter]
+        return self.get_entries()[letter]
 
 
 class GlossaryStateView(BrowserView):
@@ -138,9 +138,9 @@ class JsonView(BrowserView):
         self.request = request
 
     @ram.cache(_catalog_counter_cachekey)
-    def get_json_items(self):
+    def get_json_entries(self):
         """Get all itens and prepare in the desired format.
-        Note: do not name it get_items, otherwise caching is broken. """
+        Note: do not name it get_entries, otherwise caching is broken. """
 
         catalog = api.portal.get_tool('portal_catalog')
 
@@ -157,4 +157,4 @@ class JsonView(BrowserView):
         response = self.request.response
         response.setHeader('content-type', 'application/json')
 
-        return response.setBody(json.dumps(self.get_json_items()))
+        return response.setBody(json.dumps(self.get_json_entries()))

--- a/src/collective/glossary/tests/test_views.py
+++ b/src/collective/glossary/tests/test_views.py
@@ -43,10 +43,12 @@ class TermViewTestCase(BaseViewTestCase):
         super(TermViewTestCase, self).setUp()
         self.view = api.content.get_view(u'view', self.t1, self.request)
 
-    def test_prepare_item(self):
+    def test_get_item(self):
         self.assertEqual(
-            self.view.prepare_item(),
-            {'description': 'First Term Description', 'image': None, 'title': 'First Term'}
+            self.view.get_item(),
+            {'description': 'First Term Description',
+             'image': None,
+             'title': 'First Term'}
         )
 
 
@@ -56,9 +58,9 @@ class GlossaryViewTestCase(BaseViewTestCase):
         super(GlossaryViewTestCase, self).setUp()
         self.view = api.content.get_view(u'view', self.g1, self.request)
 
-    def test_prepare_items(self):
+    def test_get_items(self):
         self.assertEqual(
-            self.view.prepare_items(),
+            self.view.get_items(),
             {
                 'F': [{
                     'image': None,
@@ -79,11 +81,15 @@ class GlossaryViewTestCase(BaseViewTestCase):
     def test_terms(self):
         self.assertEqual(
             self.view.terms('F'),
-            [{'image': None, 'description': 'First Term Description', 'title': 'First Term'}]
+            [{'image': None,
+              'description': 'First Term Description',
+              'title': 'First Term'}]
         )
         self.assertEqual(
             self.view.terms('S'),
-            [{'image': None, 'description': 'Second Term Description', 'title': 'Second Term'}]
+            [{'image': None,
+              'description': 'Second Term Description',
+              'title': 'Second Term'}]
         )
 
 
@@ -149,11 +155,13 @@ class JsonViewTestCase(BaseViewTestCase):
 
     def setUp(self):
         super(JsonViewTestCase, self).setUp()
-        self.view = api.content.get_view(u'glossary', self.portal, self.request)
+        self.view = api.content.get_view(u'glossary',
+                                         self.portal,
+                                         self.request)
 
-    def test_get_items(self):
+    def test_get_json_items(self):
         self.assertEqual(
-            self.view.prepare_items(),
+            self.view.get_json_items(),
             [{'description': 'First Term Description', 'term': 'First Term'},
              {'description': 'Second Term Description', 'term': 'Second Term'}]
         )

--- a/src/collective/glossary/tests/test_views.py
+++ b/src/collective/glossary/tests/test_views.py
@@ -7,7 +7,6 @@ from zope.interface import alsoProvides
 from zope.publisher.browser import TestRequest
 
 import unittest
-import json
 
 
 class BaseViewTestCase(unittest.TestCase):
@@ -156,9 +155,11 @@ class JsonViewTestCase(BaseViewTestCase):
 
     def setUp(self):
         super(JsonViewTestCase, self).setUp()
-        self.view = api.content.get_view(u'glossary',
-                                         self.portal,
-                                         self.request)
+        self.view = api.content.get_view(
+            u'glossary',
+            self.portal,
+            self.request
+        )
 
     def test_get_json_entries(self):
         self.assertEqual(
@@ -168,6 +169,8 @@ class JsonViewTestCase(BaseViewTestCase):
         )
 
     def test__call__(self):
+        import json
+
         self.view()
         result = self.view.request.response.getBody()
         self.assertEqual(

--- a/src/collective/glossary/tests/test_views.py
+++ b/src/collective/glossary/tests/test_views.py
@@ -7,6 +7,7 @@ from zope.interface import alsoProvides
 from zope.publisher.browser import TestRequest
 
 import unittest
+import json
 
 
 class BaseViewTestCase(unittest.TestCase):
@@ -43,9 +44,9 @@ class TermViewTestCase(BaseViewTestCase):
         super(TermViewTestCase, self).setUp()
         self.view = api.content.get_view(u'view', self.t1, self.request)
 
-    def test_get_item(self):
+    def test_get_entry(self):
         self.assertEqual(
-            self.view.get_item(),
+            self.view.get_entry(),
             {'description': 'First Term Description',
              'image': None,
              'title': 'First Term'}
@@ -58,9 +59,9 @@ class GlossaryViewTestCase(BaseViewTestCase):
         super(GlossaryViewTestCase, self).setUp()
         self.view = api.content.get_view(u'view', self.g1, self.request)
 
-    def test_get_items(self):
+    def test_get_entries(self):
         self.assertEqual(
-            self.view.get_items(),
+            self.view.get_entries(),
             {
                 'F': [{
                     'image': None,
@@ -159,9 +160,18 @@ class JsonViewTestCase(BaseViewTestCase):
                                          self.portal,
                                          self.request)
 
-    def test_get_json_items(self):
+    def test_get_json_entries(self):
         self.assertEqual(
-            self.view.get_json_items(),
+            self.view.get_json_entries(),
+            [{'description': 'First Term Description', 'term': 'First Term'},
+             {'description': 'Second Term Description', 'term': 'Second Term'}]
+        )
+
+    def test__call__(self):
+        self.view()
+        result = self.view.request.response.getBody()
+        self.assertEqual(
+            json.loads(result),
             [{'description': 'First Term Description', 'term': 'First Term'},
              {'description': 'Second Term Description', 'term': 'Second Term'}]
         )


### PR DESCRIPTION
This fixes #4 

Problem was, that making catalog searches in the browser view's init method doesnt work cause of missing acquisition chain (see http://docs.plone.org/develop/plone/views/browserviews.html#view-init-method-special-cases)

Cause "prepare_item{s}" as name doesnt make sense anymore, i renamed them to get_items.

I fixed the unit tests, but had problem running the robot ones. So I cant look at them.