### PR TITLE
Issue 22 - Change glossary to always call json view from the portal url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Change glossary to always call json view from the portal url (closes `#22`).
+  [rodfersou]
+
 - A new rich text field was added to the Glossary content type.
   [hvelarde]
 
@@ -36,3 +39,4 @@ Changelog
 .. _`#12`: https://github.com/collective/collective.cover/issues/12
 .. _`#14`: https://github.com/collective/collective.cover/issues/14
 .. _`#18`: https://github.com/collective/collective.cover/issues/18
+.. _`#22`: https://github.com/collective/collective.cover/issues/22

--- a/src/collective/glossary/browser/configure.zcml
+++ b/src/collective/glossary/browser/configure.zcml
@@ -45,7 +45,7 @@
 
   <browser:page
       name="glossary"
-      for="*"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
       class=".views.JsonView"
       permission="zope2.View"
       layer="collective.glossary.interfaces.IGlossaryLayer"

--- a/src/collective/glossary/browser/static/main.js
+++ b/src/collective/glossary/browser/static/main.js
@@ -1,6 +1,6 @@
 $(function(){
   $('#content-core').glossarizer({
-    sourceURL: '@@glossary',
+    sourceURL: portal_url + '/@@glossary',
     callback: function() {
       // Callback fired after glossarizer finishes its job
       new tooltip();


### PR DESCRIPTION
closes #22 