### PR TITLE
language specific sorting of glossary terms using zope.ucol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 - Drop support for Plone 5.0.
   [hvelarde]
 
+- language specific sorting of terms with the same later using zope.ucol
+  [ajung]
 
 1.0b1 (2016-12-19)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'zope.i18nmessageid',
         'zope.interface',
         'zope.schema',
+        'zope.ucol'
     ],
     extras_require={
         'test': [

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from collective.glossary.interfaces import IGlossarySettings
 from plone import api
 from plone.i18n.normalizer.base import baseNormalize
@@ -8,6 +9,7 @@ from Products.Five.browser import BrowserView
 from zope.component import getMultiAdapter
 
 import json
+import plone.api
 import zope.ucol
 
 
@@ -39,15 +41,6 @@ class GlossaryView(BrowserView):
 
     """Default view of Glossary type"""
 
-    def language(self):
-        """
-        @return: Two-letter string, the active language code
-        """
-        context = self.context.aq_inner
-        portal_state = getMultiAdapter((context, self.request), name=u'plone_portal_state')
-        current_language = portal_state.language()
-        return current_language
-
     @ram.cache(_catalog_counter_cachekey)
     def get_entries(self):
         """Get glossary entries and keep them in the desired format"""
@@ -71,7 +64,8 @@ class GlossaryView(BrowserView):
             }
             items[index].append(item)
 
-        collator = zope.ucol.Collator(str(self.language()))
+        language = api.portal.get_current_language()
+        collator = zope.ucol.Collator(str(language))
 
         for k in items:
             items[k] = sorted(items[k], key=lambda term: collator.key(safe_unicode(term['title'])))

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -8,7 +8,6 @@ from plone.memoize import ram
 from Products.Five.browser import BrowserView
 from Products.CMFPlone.utils import safe_unicode
 
-import operator
 import json
 
 
@@ -72,8 +71,7 @@ class GlossaryView(BrowserView):
             }
             items[index].append(item)
 
-        language = self.language()
-        collator = zope.ucol.Collator('language')
+        collator = zope.ucol.Collator(self.language())
 
         for k in items:
             items[k] = sorted(items[k], key=lambda term: collator.key(safe_unicode(term['title'])))

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 from collective.glossary.interfaces import IGlossarySettings
-from zope.component import getMultiAdapter
-import zope.ucol
 from plone import api
 from plone.i18n.normalizer.base import baseNormalize
 from plone.memoize import ram
-from Products.Five.browser import BrowserView
 from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
+from zope.component import getMultiAdapter
 
 import json
+import zope.ucol
 
 
 def _catalog_counter_cachekey(method, self):

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -71,7 +71,7 @@ class GlossaryView(BrowserView):
             }
             items[index].append(item)
 
-        collator = zope.ucol.Collator(self.language())
+        collator = zope.ucol.Collator(str(self.language()))
 
         for k in items:
             items[k] = sorted(items[k], key=lambda term: collator.key(safe_unicode(term['title'])))

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -6,10 +6,8 @@ from plone.i18n.normalizer.base import baseNormalize
 from plone.memoize import ram
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
-from zope.component import getMultiAdapter
 
 import json
-import plone.api
 import zope.ucol
 
 


### PR DESCRIPTION
Sorting of terms should be language specific because every language has its own sorting rules.