### PR TITLE
Try to speed up GitHub Actions

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -112,3 +112,8 @@ scripts =
 [versions]
 # Don't use a released version of collective.glossary
 collective.glossary =
+# Use whatever is installed in the virtualenv for pip/buildout and friends.
+pip =
+setuptools =
+wheel =
+zc.buildout =

--- a/base.cfg
+++ b/base.cfg
@@ -29,7 +29,6 @@ environment-vars =
     zope_i18n_compile_mo_files true
 eggs =
     Plone
-    Pillow
     collective.glossary [test]
 
 [vscode]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
--c https://dist.plone.org/release/6.0-latest/constraints.txt
--r https://dist.plone.org/release/6.0-latest/requirements.txt
+pip==23.1.2
+setuptools==67.8.0
+wheel==0.40.0
+zc.buildout==3.0.1

--- a/requirements_52.txt
+++ b/requirements_52.txt
@@ -1,2 +1,0 @@
--c https://dist.plone.org/release/5.2-latest/constraints.txt
--r https://dist.plone.org/release/5.2-latest/requirements.txt

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -8,3 +8,7 @@ extends =
 update-versions-file = test_plone52.cfg
 
 [versions]
+
+# Added by buildout at 2023-06-27 11:23:53.383420
+collective.recipe.vscode = 0.1.8
+createcoverage = 1.5

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -8,4 +8,3 @@ extends =
 update-versions-file = test_plone52.cfg
 
 [versions]
-Pillow=

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -8,29 +8,43 @@ extends =
 update-versions-file = test_plone60.cfg
 
 [versions]
-# Added by buildout at 2022-07-28 07:58:08.026241
-bleach = 5.0.1
-commonmark = 0.9.1
-coverage = 6.4.2
+
+# Added by buildout at 2023-06-27 11:31:52.479883
+bleach = 6.0.0
+coverage = 7.2.7
 createcoverage = 1.5
-i18ndude = 5.4.2
-keyring = 23.7.0
-pkginfo = 1.8.3
-readme-renderer = 35.0
-requests-toolbelt = 0.9.1
+i18ndude = 6.0.0
+keyring = 24.2.0
+markdown-it-py = 3.0.0
+mdurl = 0.1.2
+pkginfo = 1.9.6
+readme-renderer = 40.0
+requests-toolbelt = 1.0.0
 rfc3986 = 2.0.0
-rich = 12.5.1
-twine = 4.0.1
-zest.releaser = 6.22.2
+rich = 13.4.2
+twine = 4.0.2
+zest.releaser = 8.0.0
 
 # Required by:
-# zest.releaser==6.22.2
-colorama = 0.4.5
+# zest.releaser==8.0.0
+colorama = 0.4.6
 
 # Required by:
-# bleach==5.0.1
+# keyring==24.2.0
+jaraco.classes = 3.2.3
+
+# Required by:
+# jaraco.classes==3.2.3
+more-itertools = 9.1.0
+
+# Required by:
+# zest.releaser==8.0.0
+tomli = 2.0.1
+
+# Required by:
+# bleach==6.0.0
 webencodings = 0.5.1
 
 # Required by:
-# collective.glossary==1.2.dev0
-z3c.jbot = 1.1.1
+# collective.glossary==2.0.4.dev0
+z3c.jbot = 2.0

--- a/test_plone60.cfg
+++ b/test_plone60.cfg
@@ -8,10 +8,7 @@ extends =
 update-versions-file = test_plone60.cfg
 
 [versions]
-Pillow=
-
 # Added by buildout at 2022-07-28 07:58:08.026241
-Pillow = 9.2.0
 bleach = 5.0.1
 commonmark = 0.9.1
 coverage = 6.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,7 @@ setenv =
     plone52: version_file=test_plone52.cfg
 
 deps =
-    plone60: -rrequirements.txt
-    plone52: -rrequirements_52.txt
+    -rrequirements.txt
     coverage
 
 [testenv:coverage-report]


### PR DESCRIPTION
First change: Do not test Plone 6.0 on Python 3.8.
We *do* want to test this, but gh-actions with tox and tox-gh-actions combines the Plone 5.2 and 6.0 tests and this takes really long. 23 minutes currently. I wonder if it is still slow when only running the 5.2 tests. Expect a few commits while I try to figure some things out.