### PR TITLE
Show A-Z toolbar and hide contents when there are more than 30 entries.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
+- Show A-Z toolbar and hide contents when there are more than 30 entries.
+  You can override the default with environment variable
+  ``COLLECTIVE_GLOSSARY_MAXIMUM_WITHOUT_AZ_TOOLBAR``.
+  To never show the toolbar, set this to a negative number (-1).
+  [ingo, maurits]
+
 - Add Dutch translations, contributed by Flemish Environment Agency [fredvd].
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,7 @@ Changelog
 ------------------
 
 - Show A-Z toolbar and hide contents when there are more than 30 entries.
-  You can override the default with environment variable
-  ``COLLECTIVE_GLOSSARY_MAXIMUM_WITHOUT_AZ_TOOLBAR``.
+  You can configure this in the controlpanel.
   To never show the toolbar, set this to a negative number (-1).
   [ingo, maurits]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,17 +6,7 @@ ignore =
     .gitattributes
 
 [isort]
-# black compatible isort rules:
-force_alphabetical_sort = True
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses = True
-lines_after_imports = 2
-line_length = 88
-not_skip =
-    __init__.py
-skip =
+profile = plone
 
 [flake8]
 # black compatible flake8 rules:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Installer for the collective.glossary package."""
 
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 
 long_description = "\n\n".join(

--- a/src/collective/glossary/api/services/glossary/get.py
+++ b/src/collective/glossary/api/services/glossary/get.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import defaultdict
+from collective.glossary.config import DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR
 from collective.glossary.interfaces import IGlossarySettings
 from plone import api
 from plone.i18n.normalizer.base import baseNormalize
@@ -55,6 +56,11 @@ class GetGlossaryTerms(Service):
                 name="enabled_content_types",
                 interface=IGlossarySettings,
                 default=[],
+            ),
+            "maximum_without_az_toolbar": api.portal.get_registry_record(
+                name="maximum_without_az_toolbar",
+                interface=IGlossarySettings,
+                default=DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR,
             ),
         }
 

--- a/src/collective/glossary/browser/templates/glossary.pt
+++ b/src/collective/glossary/browser/templates/glossary.pt
@@ -21,40 +21,53 @@
           <div tal:content="structure text">The body</div>
         </div>
 
-        <tal:repeat repeat="letter view/letters">
-          <div class="letter">
-            <div class="header">
-              <div class="title" tal:content="letter"></div>
-            </div>
-            <div class="terms">
-              <tal:repeat repeat="item python:view.terms(letter)">
-                <a class="term"
-                  tal:attributes="
-                    class python:'term ' + item['state'];
-                    href python: item['url']
-                  ">
-                  <img tal:define="image item/image"
-                      tal:condition="nocall:image"
-                      tal:replace="structure image/tag" />
-                  <div class="description-wrapper">
-                    <div class="description">
-                      <span class="title"
-                            tal:content="item/title">
-                      </span>
-                      <span class="variants" tal:condition="python:item['variants']"> - 
-                        <span tal:content="python:', '.join(item['variants'])">variants</span>
-                      </span>
-                      -
-                      <span class="definition"
-                            tal:content="structure python:item['definition']">
-                      </span>
+        <nav id="navbar-glossary"
+             class="navbar d-flex justify-content-center glossary-nav"
+             tal:condition="view/use_az_toolbar">
+          <ul class="pagination" role="tablist">
+            <tal:repeat repeat="letter view/letters">
+              <li class="page-item"><button class="nav-link page-link" data-bs-toggle="pill" data-bs-target="#t${letter}" type="button" tal:content="letter" /></li>
+            </tal:repeat>
+          </ul>
+        </nav>
+
+        <div data-target="#navbar-glossary" data-offset="0" class="tab-content"
+             tal:define="extra_classes python:'' if view.use_az_toolbar else 'active show'">
+          <tal:repeat repeat="letter view/letters">
+            <div class="letter tab-pane fade ${extra_classes}" id="t${letter}" role="tabpanel" tabindex="0">
+              <div class="header">
+                <div class="title" tal:content="letter"></div>
+              </div>
+              <div class="terms">
+                <tal:repeat repeat="item python:view.terms(letter)">
+                  <a class="term"
+                    tal:attributes="
+                      class python:'term ' + item['state'];
+                      href python: item['url']
+                    ">
+                    <img tal:define="image item/image"
+                        tal:condition="nocall:image"
+                        tal:replace="structure image/tag" />
+                    <div class="description-wrapper">
+                      <div class="description">
+                        <span class="title"
+                              tal:content="item/title">
+                        </span>
+                        <span class="variants" tal:condition="python:item['variants']"> -
+                          <span tal:content="python:', '.join(item['variants'])">variants</span>
+                        </span>
+                        -
+                        <span class="definition"
+                              tal:content="structure python:item['definition']">
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                </a>
-              </tal:repeat>
+                  </a>
+                </tal:repeat>
+              </div>
             </div>
-          </div>
-        </tal:repeat>
+          </tal:repeat>
+        </div>
       </metal:content-core>
     </metal:content-core>
   </body>

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -7,18 +7,9 @@ from Products.Five.browser import BrowserView
 
 import json
 import logging
-import os
 
 
 logger = logging.getLogger(__name__)
-
-# Maximum amount of entries before we show the A-Z toolbar:
-env_name = "COLLECTIVE_GLOSSARY_MAXIMUM_WITHOUT_AZ_TOOLBAR"
-try:
-    MAXIMUM_WITHOUT_AZ_TOOLBAR = int(os.environ.get(env_name))
-    logger.info("Using %d as maximum without AZ toolbar.", MAXIMUM_WITHOUT_AZ_TOOLBAR)
-except Exception:
-    MAXIMUM_WITHOUT_AZ_TOOLBAR = 30
 
 
 class TermView(BrowserView):
@@ -86,13 +77,16 @@ class GlossaryView(BrowserView):
         You can override the default maximum with an environment variable.
         To never show the toolbar, set this to a negative number (-1).
         """
-        if MAXIMUM_WITHOUT_AZ_TOOLBAR < 0:
+        maximum_without_az_toolbar = api.portal.get_registry_record(
+            IGlossarySettings.__identifier__ + ".maximum_without_az_toolbar"
+        )
+        if maximum_without_az_toolbar < 0:
             return False
         total = 0
         # Keep counting until we have reached the maximum.
         for letter, entries in self.get_entries().items():
             total += len(entries)
-            if total > MAXIMUM_WITHOUT_AZ_TOOLBAR:
+            if total > maximum_without_az_toolbar:
                 return True
         return False
 

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -74,7 +74,7 @@ class GlossaryView(BrowserView):
         the entries for this letter are shown.
 
         For small glossaries this makes no sense, so we show them all.
-        You can override the default maximum with an environment variable.
+        You can override the default maximum in the control panel.
         To never show the toolbar, set this to a negative number (-1).
         """
         maximum_without_az_toolbar = api.portal.get_registry_record(

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collective.glossary.config import DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR
 from collective.glossary.interfaces import IGlossarySettings
 from functools import cached_property
 from plone import api

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from collections import defaultdict
 from collective.glossary.config import DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR
 from collective.glossary.interfaces import IGlossarySettings
@@ -80,7 +81,7 @@ class GlossaryView(BrowserView):
         """
         maximum_without_az_toolbar = api.portal.get_registry_record(
             IGlossarySettings.__identifier__ + ".maximum_without_az_toolbar",
-            default=DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR
+            default=DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR,
         )
         if maximum_without_az_toolbar < 0:
             return False

--- a/src/collective/glossary/browser/views.py
+++ b/src/collective/glossary/browser/views.py
@@ -78,7 +78,8 @@ class GlossaryView(BrowserView):
         To never show the toolbar, set this to a negative number (-1).
         """
         maximum_without_az_toolbar = api.portal.get_registry_record(
-            IGlossarySettings.__identifier__ + ".maximum_without_az_toolbar"
+            IGlossarySettings.__identifier__ + ".maximum_without_az_toolbar",
+            default=DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR
         )
         if maximum_without_az_toolbar < 0:
             return False

--- a/src/collective/glossary/config.py
+++ b/src/collective/glossary/config.py
@@ -10,3 +10,6 @@ DEFAULT_ENABLED_CONTENT_TYPES = [
     "Link",
     "News Item",
 ]
+
+# maximum number of entries before we show the A-Z toolbar:
+DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR = 30

--- a/src/collective/glossary/content.py
+++ b/src/collective/glossary/content.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from collective.glossary.interfaces import IGlossary, ITerm
-from plone.dexterity.content import Container, Item
+from collective.glossary.interfaces import IGlossary
+from collective.glossary.interfaces import ITerm
+from plone.dexterity.content import Container
+from plone.dexterity.content import Item
 from zope.interface import implementer
 
 

--- a/src/collective/glossary/interfaces.py
+++ b/src/collective/glossary/interfaces.py
@@ -6,7 +6,8 @@ from plone.app.textfield import RichText
 from plone.autoform import directives as form
 from plone.namedfile.field import NamedBlobImage
 from plone.supermodel import model
-from z3c.form.interfaces import IAddForm, IEditForm
+from z3c.form.interfaces import IAddForm
+from z3c.form.interfaces import IEditForm
 from zope import schema
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer

--- a/src/collective/glossary/interfaces.py
+++ b/src/collective/glossary/interfaces.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.glossary import _
 from collective.glossary.config import DEFAULT_ENABLED_CONTENT_TYPES
+from collective.glossary.config import DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR
 from plone.app.textfield import RichText
 from plone.autoform import directives as form
 from plone.namedfile.field import NamedBlobImage
@@ -33,6 +34,12 @@ class IGlossarySettings(Interface):
         default=DEFAULT_ENABLED_CONTENT_TYPES,
         # we are going to list only the main content types in the widget
         value_type=schema.Choice(vocabulary="collective.glossary.PortalTypes"),
+    )
+
+    maximum_without_az_toolbar = schema.Int(
+        title=_("Maximum before showing A-Z toolbar"),
+        description=_("Maximum number of entries before we show the A-Z toolbar."),
+        default=DEFAULT_MAXIMUM_WITHOUT_AZ_TOOLBAR,
     )
 
 

--- a/src/collective/glossary/profiles/default/metadata.xml
+++ b/src/collective/glossary/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4</version>
+  <version>5</version>
   <dependencies>
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/src/collective/glossary/testing.py
+++ b/src/collective/glossary/testing.py
@@ -5,7 +5,9 @@ For Plone 5 we need to install plone.app.contenttypes.
 """
 from plone import api
 from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
-from plone.app.testing import FunctionalTesting, IntegrationTesting, PloneSandboxLayer
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 
 import pkg_resources

--- a/src/collective/glossary/tests/test_controlpanel.py
+++ b/src/collective/glossary/tests/test_controlpanel.py
@@ -4,7 +4,8 @@ from collective.glossary.interfaces import IGlossaryLayer
 from collective.glossary.testing import INTEGRATION_TESTING
 from plone.app.testing import logout
 from plone.registry.interfaces import IRegistry
-from zope.component import getMultiAdapter, getUtility
+from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.interface import alsoProvides
 
 import unittest

--- a/src/collective/glossary/tests/test_glossary.py
+++ b/src/collective/glossary/tests/test_glossary.py
@@ -3,7 +3,8 @@ from collective.glossary.interfaces import IGlossary
 from collective.glossary.testing import INTEGRATION_TESTING
 from plone import api
 from plone.dexterity.interfaces import IDexterityFTI
-from zope.component import createObject, queryUtility
+from zope.component import createObject
+from zope.component import queryUtility
 
 import unittest
 

--- a/src/collective/glossary/tests/test_term.py
+++ b/src/collective/glossary/tests/test_term.py
@@ -3,7 +3,8 @@ from collective.glossary.interfaces import ITerm
 from collective.glossary.testing import INTEGRATION_TESTING
 from plone import api
 from plone.dexterity.interfaces import IDexterityFTI
-from zope.component import createObject, queryUtility
+from zope.component import createObject
+from zope.component import queryUtility
 
 import unittest
 

--- a/src/collective/glossary/upgrades/configure.zcml
+++ b/src/collective/glossary/upgrades/configure.zcml
@@ -2,4 +2,5 @@
   <include package=".v2" />
   <include package=".v2a" />
   <include package=".v2b" />
+  <include package=".v2c" />
 </configure>

--- a/src/collective/glossary/upgrades/v2c/configure.zcml
+++ b/src/collective/glossary/upgrades/v2c/configure.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="collective.glossary">
+
+  <genericsetup:upgradeSteps
+      source="4"
+      destination="5"
+      profile="collective.glossary:default">
+
+      <genericsetup:upgradeDepends
+          title="Re-apply registry to add record for maximum_without_az_toolbar"
+          import_steps="plone.app.registry"
+          />
+
+  </genericsetup:upgradeSteps>
+
+</configure>


### PR DESCRIPTION
You can override the default with environment variable `COLLECTIVE_GLOSSARY_MAXIMUM_WITHOUT_AZ_TOOLBAR`. To never show the toolbar, set this to a negative number (-1).

Idea from and initial implementation done by a customer (Ingo).  Thanks!

Screen shot (with minor client-specific styling that is not in this PR) with a lot of letters (only the 'Y' is missing, and with the entries for 'U' loaded):

![Screenshot 2023-10-11 at 12 09 23](https://github.com/collective/collective.glossary/assets/210587/080ef148-fccc-4b69-a16e-20a6d74dbf9d)

This is with a small window.  On a large window, all letters fit on my screen.

In default Plone with just three letters (but lots of entries):

![Screenshot 2023-10-11 at 12 15 40](https://github.com/collective/collective.glossary/assets/210587/4caaf95b-48ab-44c9-b16c-3121a00d04cd)
