### PR TITLE
Service "@tooltip_terms" returns terms in context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Service "@tooltip_terms" now returns terms in context. This supports multilingual sites.
+  [ksuess]
 
 
 2.1.1 (2023-12-19)

--- a/src/collective/glossary/api/services/glossary/get.py
+++ b/src/collective/glossary/api/services/glossary/get.py
@@ -83,9 +83,8 @@ class GetTooltipTerms(Service):
 
         Terms are all titles and variants with their list of definitions."""
 
-        catalog = api.portal.get_tool("portal_catalog")
+        terms = api.content.find(context=self.context, portal_type="Term")
 
-        terms = catalog(portal_type="Term")
         terms_with_variants = defaultdict(list)
         for term in terms:
             obj = term.getObject()


### PR DESCRIPTION
This supports multilingual sites.