### PR TITLE
Service "@tooltip_terms" returns terms in context.

### DIFF
--- a/news/1017.feature
+++ b/news/1017.feature
@@ -1,0 +1,1 @@
+Service "@tooltip_terms" returns terms in context. This supports multilingual sites. @ksuess

--- a/src/collective/glossary/api/services/glossary/get.py
+++ b/src/collective/glossary/api/services/glossary/get.py
@@ -81,9 +81,7 @@ class GetTooltipTerms(Service):
 
         Terms are all titles and variants with their list of definitions."""
 
-        catalog = api.portal.get_tool("portal_catalog")
-
-        terms = catalog(portal_type="Term")
+        terms = api.content.find(context=self.context, portal_type="Term")
         terms_with_variants = defaultdict(list)
         for term in terms:
             obj = term.getObject()


### PR DESCRIPTION
This supports multilingual sites.